### PR TITLE
AO3-6791 Raise 404 when editing a pseud for a user that doesn't exist

### DIFF
--- a/app/controllers/pseuds_controller.rb
+++ b/app/controllers/pseuds_controller.rb
@@ -74,8 +74,12 @@ class PseudsController < ApplicationController
 
   # GET /pseuds/1/edit
   def edit
-    @pseud = @user.pseuds.find_by(name: params[:id])
-    authorize @pseud if logged_in_as_admin?
+    if @user
+      @pseud = @user.pseuds.find_by(name: params[:id])
+      authorize @pseud if logged_in_as_admin?
+    else
+      raise ActiveRecord::RecordNotFound, "Couldn't find user '#{params[:user_id]}'"
+    end
   end
 
   # POST /pseuds

--- a/app/controllers/pseuds_controller.rb
+++ b/app/controllers/pseuds_controller.rb
@@ -74,12 +74,10 @@ class PseudsController < ApplicationController
 
   # GET /pseuds/1/edit
   def edit
-    if @user
-      @pseud = @user.pseuds.find_by(name: params[:id])
-      authorize @pseud if logged_in_as_admin?
-    else
-      raise ActiveRecord::RecordNotFound, "Couldn't find user '#{params[:user_id]}'"
-    end
+    raise ActiveRecord::RecordNotFound, "Couldn't find user '#{params[:user_id]}'" unless @user
+
+    @pseud = @user.pseuds.find_by(name: params[:id])
+    authorize @pseud if logged_in_as_admin?
   end
 
   # POST /pseuds

--- a/spec/controllers/pseuds_controller_spec.rb
+++ b/spec/controllers/pseuds_controller_spec.rb
@@ -76,6 +76,10 @@ describe PseudsController do
             subject.call
             expect(response).to render_template(:edit)
           end
+
+          it "returns NotFound error when pseud doesn't exist" do
+            expect { get :edit, params: { user_id: "fake_user", id: pseud } }.to raise_error(ActiveRecord::RecordNotFound)
+          end
         end
       end
     end

--- a/spec/controllers/pseuds_controller_spec.rb
+++ b/spec/controllers/pseuds_controller_spec.rb
@@ -78,7 +78,8 @@ describe PseudsController do
           end
 
           it "returns NotFound error when pseud doesn't exist" do
-            expect { get :edit, params: { user_id: "fake_user", id: pseud } }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { get :edit, params: { user_id: "fake_user", id: pseud } }
+              .to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/)?
* [x] Have you read the [contributing guidelines](https://github.com/otwcode/otwarchive/blob/master/CONTRIBUTING.md)?
* [x] Have you added [tests for any changed functionality](https://github.com/otwcode/otwarchive/wiki/Automated-Testing)?
* [x] Have you added the [Jira](https://otwarchive.atlassian.net) issue number
  as the *first* thing in your pull request title (e.g. `AO3-1234 Fix thing`)
* [x] Do you have fewer than 5 pull requests already open? If not, please wait
  until they are reviewed and merged before creating new pull requests.

## Issue

https://otwarchive.atlassian.net/browse/AO3-6791

## Purpose

When navigating to a pseud edit page for a user that doesn't exist (/users/fake_user/pseuds/pseud/edit), we should return a 404 error, instead of a 500

## Testing Instructions
Replication steps from JIRA:
1. Log in as an admin who can edit pseuds (policy_and_abuse or superadmin)
2. Try to edit a pseud for a nonexistent user. For example, assuming the user no_testy does not exist, enter this URL in your browser: https://test.archiveofourown.org/users/no_testy/pseuds/no_testy/edit

## References

Are there other relevant issues/pull requests/mailing list discussions?
Linked jira issue [AO3-6790](https://otwarchive.atlassian.net/browse/AO3-6790) to raise 404 when editing a pseud that doesn't exist, and its PR.

## Credit
lou (she/her)